### PR TITLE
Use crypto.randomBytes instead of Math.random

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ npm install -g ts-pwgen
 ## Good to know
 * It has a default password length of 30 characters
 * It uses lowercase/uppercase letters, numbers and special characters when you don't pass any arguments saying otherwise
+* It uses [`crypto.randomBytes()`](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback) instead of `Math.random()`.
 * You should try the `--verbose` flag to see how long it would take a supercomputer to crack your generated password
 * Use `-k` if you don't like the copy-to-clipboard feature
 

--- a/lib/dest/password_generator.js
+++ b/lib/dest/password_generator.js
@@ -11,6 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 require("colors");
 const inquirer = require("inquirer");
 const copyPaste = require("copy-paste");
+const crypto = require("crypto");
 const charsets_1 = require("./charsets");
 const defaultOptions = {
     lowercaseLetters: true,
@@ -56,6 +57,14 @@ class PasswordGenerator {
         let { amount, length, delimiter } = this.options.parts;
         return amount * length + amount * delimiter.length;
     }
+    random() {
+        let rand = crypto.randomBytes(32).readUInt32LE(0);
+        if (rand === 0) {
+            return 0;
+        }
+        rand /= Math.pow(10, (Math.floor(Math.log10(Math.abs(rand)) + 1) - 1));
+        return rand - Math.trunc(rand);
+    }
     /**
      * Generates a password based on this.options. This method will recursively
      * call itself if the password does not contain at least one character from
@@ -93,7 +102,7 @@ class PasswordGenerator {
         for (let partIndex = 0; partIndex < amount; partIndex++) {
             let part = '';
             while (part.length < length) {
-                let randomIndex = Math.floor(Math.random() * list.length);
+                let randomIndex = Math.floor(this.random() * list.length);
                 part += list[randomIndex];
             }
             // If this is not the last part, add the delimiter.

--- a/lib/dest/password_generator.js
+++ b/lib/dest/password_generator.js
@@ -58,12 +58,10 @@ class PasswordGenerator {
         return amount * length + amount * delimiter.length;
     }
     random() {
-        let rand = crypto.randomBytes(32).readUInt32LE(0);
-        if (rand === 0) {
-            return 0;
-        }
-        rand /= Math.pow(10, (Math.floor(Math.log10(Math.abs(rand)) + 1) - 1));
-        return rand - Math.trunc(rand);
+        // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64
+        let mantissa = crypto.randomBytes(6).toString('hex') + '0';
+        let hex_representation = '3ff' + mantissa;
+        return new Buffer(hex_representation, 'hex').readDoubleBE(0) - 1;
     }
     /**
      * Generates a password based on this.options. This method will recursively

--- a/lib/dest/password_generator.js
+++ b/lib/dest/password_generator.js
@@ -57,11 +57,14 @@ class PasswordGenerator {
         let { amount, length, delimiter } = this.options.parts;
         return amount * length + amount * delimiter.length;
     }
+    /**
+     * Generate a cryptographically more secure random number than Math.random().
+     */
     random() {
         // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64
         let mantissa = crypto.randomBytes(6).toString('hex') + '0';
-        let hex_representation = '3ff' + mantissa;
-        return new Buffer(hex_representation, 'hex').readDoubleBE(0) - 1;
+        let hexRepresentation = '3ff' + mantissa;
+        return new Buffer(hexRepresentation, 'hex').readDoubleBE(0) - 1;
     }
     /**
      * Generates a password based on this.options. This method will recursively

--- a/lib/dest/password_generator.spec.js
+++ b/lib/dest/password_generator.spec.js
@@ -161,4 +161,15 @@ describe('PasswordGenerator', () => {
             chai_1.expect(pwgen.countActiveCharsets()).to.be.equal(5);
         });
     });
+    describe('#random()', () => {
+        it('should average at about 0.5', () => {
+            let pwgen = new password_generator_1.PasswordGenerator();
+            let all = [];
+            for (let i = 0; i < 10000; i++) {
+                all.push(pwgen.random());
+            }
+            let average = all.reduce((prev, curr) => curr += prev, 0) / all.length;
+            chai_1.expect(average).to.be.approximately(0.5, 0.01);
+        });
+    });
 });

--- a/lib/src/password_generator.spec.ts
+++ b/lib/src/password_generator.spec.ts
@@ -177,6 +177,19 @@ describe('PasswordGenerator', () => {
       });
       expect(pwgen.countActiveCharsets()).to.be.equal(5);
     });
-  })
+  });
+
+  describe('#random()', () => {
+    it('should average at about 0.5', () => {
+      let pwgen = new PasswordGenerator();
+
+      let all = [];
+      for (let i = 0; i < 10000; i++) {
+        all.push(pwgen.random());
+      }
+      let average = all.reduce((prev, curr) => curr += prev, 0) / all.length;
+      expect(average).to.be.approximately(0.5, 0.01);
+    });
+  });
 });
 

--- a/lib/src/password_generator.ts
+++ b/lib/src/password_generator.ts
@@ -4,7 +4,7 @@ import 'colors';
 import * as inquirer from 'inquirer';
 import * as copyPaste from 'copy-paste';
 import * as crypto from 'crypto';
-import { PasswordGeneratorOptions, GeneratedPassword, PasswordAnswer }  from './password_generator.interface';
+import { PasswordGeneratorOptions, GeneratedPassword, PasswordAnswer } from './password_generator.interface';
 import { latin1List, lowercaseLettersList, numbersList, specialCharactersList, uppercaseLettersList } from './charsets';
 
 const defaultOptions: PasswordGeneratorOptions = {
@@ -55,13 +55,14 @@ export class PasswordGenerator {
     return amount * length + amount * delimiter.length;
   }
 
+  /**
+   * Generate a cryptographically more secure random number than Math.random().
+   */
   private random(): number {
-    let rand = crypto.randomBytes(32).readUInt32LE(0);
-    if (rand === 0) {
-        return 0;
-    }
-    rand /= 10 ** (Math.floor(Math.log10(Math.abs(rand)) + 1) - 1);
-    return rand - Math.trunc(rand);
+    // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64
+    let mantissa = crypto.randomBytes(6).toString('hex') + '0';
+    let hexRepresentation = '3ff' + mantissa;
+    return new Buffer(hexRepresentation, 'hex').readDoubleBE(0) - 1;
   }
 
   /**
@@ -188,7 +189,7 @@ export class PasswordGenerator {
       copyPaste.copy(chosenPassword, () => {
         console.log('\nPassword successfully copied to clipboard!'.gray);
         process.exit(0);
-      });  
+      });
     } else {
       process.exit(0);
     }

--- a/lib/src/password_generator.ts
+++ b/lib/src/password_generator.ts
@@ -3,6 +3,7 @@
 import 'colors';
 import * as inquirer from 'inquirer';
 import * as copyPaste from 'copy-paste';
+import * as crypto from 'crypto';
 import { PasswordGeneratorOptions, GeneratedPassword, PasswordAnswer }  from './password_generator.interface';
 import { latin1List, lowercaseLettersList, numbersList, specialCharactersList, uppercaseLettersList } from './charsets';
 
@@ -54,6 +55,15 @@ export class PasswordGenerator {
     return amount * length + amount * delimiter.length;
   }
 
+  private random(): number {
+    let rand = crypto.randomBytes(32).readUInt32LE(0);
+    if (rand === 0) {
+        return 0;
+    }
+    rand /= 10 ** (Math.floor(Math.log10(Math.abs(rand)) + 1) - 1);
+    return rand - Math.trunc(rand);
+  }
+
   /**
    * Generates a password based on this.options. This method will recursively
    * call itself if the password does not contain at least one character from
@@ -96,7 +106,7 @@ export class PasswordGenerator {
       let part = '';
 
       while (part.length < length) {
-        let randomIndex = Math.floor(Math.random() * list.length);
+        let randomIndex = Math.floor(this.random() * list.length);
         part += list[randomIndex];
       }
 

--- a/lib/src/password_generator.ts
+++ b/lib/src/password_generator.ts
@@ -58,7 +58,7 @@ export class PasswordGenerator {
   /**
    * Generate a cryptographically more secure random number than Math.random().
    */
-  private random(): number {
+  random(): number {
     // https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64
     let mantissa = crypto.randomBytes(6).toString('hex') + '0';
     let hexRepresentation = '3ff' + mantissa;


### PR DESCRIPTION
`crypto.randomBytes` uses OpenSSL as a PRNG. Even though it is a lot slower than `Math.random()` I think this is the right approach.